### PR TITLE
Fixed pip install on Mac OSX 10.9 and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Check the [examples](https://github.com/concordusapps/python-xmlsec/tree/master/
 
 ## Install
 
+### Pre-Install
+
+#### Linux
+
+    ```sh
+    apt-get install libxml2-dev libxmlsec1-dev
+    ```
+
+#### Mac
+
+    ```sh
+    brew install libxml2 libxmlsec1
+    ```
+
 ### Automated
 
 1. **xmlsec** can be installed through `easy_install` or `pip`.
@@ -15,6 +29,11 @@ Check the [examples](https://github.com/concordusapps/python-xmlsec/tree/master/
    ```sh
    pip install xmlsec
    ```
+   
+#### Mac
+
+If you get any fatal errors about missing .h files, update your C_INCLUDE_PATH environment variable to
+include the appropriate files from the libxml2 and libxmlsec1 libraries.
 
 ### Manual
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ Check the [examples](https://github.com/concordusapps/python-xmlsec/tree/master/
 
 #### Linux
 
-    ```sh
-    apt-get install libxml2-dev libxmlsec1-dev
-    ```
+   ```sh
+   apt-get install libxml2-dev libxmlsec1-dev
+   ```
 
 #### Mac
 
-    ```sh
-    brew install libxml2 libxmlsec1
-    ```
+   ```sh
+   brew install libxml2 libxmlsec1
+   ```
 
 ### Automated
 

--- a/setup.py
+++ b/setup.py
@@ -79,15 +79,18 @@ def make_extension(name, cython=True):
 
     # Process the `pkg-config` utility and discover include and library
     # directories.
-    config = {
-        'include_dirs': [],
-    }
+    config = {}
     for lib in ['libxml-2.0', 'xmlsec1-%s' % XMLSEC_CRYPTO]:
         config.update(parse(lib))
+
+    config['extra_compile_args'] = ['-DXMLSEC_CRYPTO_OPENSSL=1']
 
     # List-ify config for setuptools.
     for key in config:
         config[key] = list(config[key])
+
+    if 'include_dirs' not in config:
+        config['include_dirs'] = []
 
     # Add the source directories for inclusion.
     config['include_dirs'].insert(0, 'src')

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,9 @@ def make_extension(name, cython=True):
 
     # Process the `pkg-config` utility and discover include and library
     # directories.
-    config = {}
+    config = {
+        'include_dirs': [],
+    }
     for lib in ['libxml-2.0', 'xmlsec1-%s' % XMLSEC_CRYPTO]:
         config.update(parse(lib))
 


### PR DESCRIPTION
Added some info to the README that took me some time to figure out. Also, added an extra compile argument to the compilation of libxmlsec1 to choose openssl as the crypto library.
